### PR TITLE
feat: add dotglob option

### DIFF
--- a/gsync
+++ b/gsync
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-shopt -s globstar nullglob
+shopt -s globstar dotglob nullglob
 
 function help {
 	local command_name


### PR DESCRIPTION
If set, this option makes Bash include filenames beginning with a "." in the results of pathname expansion. The filenames . and .. must always be matched explicitly, even if dotglob is set.

So, this option allows syncing repositories that have "." in beginning of their filenames.